### PR TITLE
Fixes dependency mismatch

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   validators: ^2.0.0+1
   path_provider: ^1.1.0
   path: ^1.6.2
-  intl: ^0.15.8
+  intl: ^0.16.0
   meta: ^1.1.6
 
 dev_dependencies:


### PR DESCRIPTION
`Because vcard 0.1.0 depends on intl ^0.15.8 and no versions of vcard match >0.1.0 <0.2.0, vcard ^0.1.0 requires intl ^0.15.8.`

This will allow users of this package to be able to use the latest version of intl (0.16.0) which contains important bug fixes.